### PR TITLE
Fixing name of deleteDelay variable

### DIFF
--- a/typer.js
+++ b/typer.js
@@ -5,7 +5,7 @@ var Typer = function(element) {
   var words = element.dataset.words || "override these,sample typing";
   this.words = words.split(delim).filter(function(v){return v;}); // non empty words
   this.delay = element.dataset.delay || 200;
-  this.deleteDelay = element.dataset.deleteDelay || 800;
+  this.deleteDelay = element.dataset.deletedelay || element.dataset.deleteDelay || 800;
 
   this.progress = { word:0, char:0, building:true, atWordEnd:false };
   this.typing = true;


### PR DESCRIPTION
I was working with Typer.js and noticed that my delete delay settings had no effect. The reason is because the way the dataset element handles attribute names. 

With an attribute called `data-deleteDelay`, it will be placed in the dataset as `dataset.deletedelay`. 

In order to access the data as it was in your original code, you'd need the attribute to be called `data-delete-delay` which will be converted to camelcase and become `dataset.deleteDelay`. 

I added a check that matches the output that would be expected based on your documentation. Alternatively you could update the documentation to reflect the `data-delete-delay`. This PR allows both options. I figured it'd be better to support the initial implementation for any existing users. 

Thanks for the plugin!