### PR TITLE
Adding the ability to control looping

### DIFF
--- a/typer.js
+++ b/typer.js
@@ -5,9 +5,10 @@ var Typer = function(element) {
   var words = element.dataset.words || "override these,sample typing";
   this.words = words.split(delim).filter(function(v){return v;}); // non empty words
   this.delay = element.dataset.delay || 200;
+  this.loop = element.dataset.loop || true;
   this.deleteDelay = element.dataset.deletedelay || element.dataset.deleteDelay || 800;
 
-  this.progress = { word:0, char:0, building:true, atWordEnd:false };
+  this.progress = { word:0, char:0, building:true, atWordEnd:false, looped: 0 };
   this.typing = true;
 
   var colors = element.dataset.colors || "black";
@@ -58,6 +59,13 @@ Typer.prototype.doTyping = function() {
       this.element.style.color = this.colors[this.colorIndex];
     }
   }
+  
+  if(p.atWordEnd) p.looped += 1;
+
+  if(!p.building && (!this.loop || this.loop <= p.looped) ){
+    this.typing = false;
+  }
+  
   var myself = this;
   setTimeout(function() {
     if (myself.typing) { myself.doTyping(); };

--- a/typer.js
+++ b/typer.js
@@ -5,7 +5,7 @@ var Typer = function(element) {
   var words = element.dataset.words || "override these,sample typing";
   this.words = words.split(delim).filter(function(v){return v;}); // non empty words
   this.delay = element.dataset.delay || 200;
-  this.loop = element.dataset.loop || true;
+  this.loop = element.dataset.loop || "true";
   this.deleteDelay = element.dataset.deletedelay || element.dataset.deleteDelay || 800;
 
   this.progress = { word:0, char:0, building:true, atWordEnd:false, looped: 0 };

--- a/typer.js
+++ b/typer.js
@@ -62,7 +62,7 @@ Typer.prototype.doTyping = function() {
   
   if(p.atWordEnd) p.looped += 1;
 
-  if(!p.building && (!this.loop || this.loop <= p.looped) ){
+  if(!p.building && (this.loop == "false" || this.loop <= p.looped) ){
     this.typing = false;
   }
   


### PR DESCRIPTION
I like the simplicity of this library. I do though think it could use the ability for a developer to set if it never loops, always loops or loops n times. So I added some code that if you add the attribute as such:

- It will loop for ever (it's also the default)
   data-loop="true"

- It will not loop at all, it will just type out once.
  data-loop="false"

- It will loop 4 times
  data-loop="4"

This unfortunately only works with non-delimited words, mainly because multiple delimitations was just not a use case for me. I will submit another change once I get to that.