### PR TITLE
Fixing cursor display object

### DIFF
--- a/typer.js
+++ b/typer.js
@@ -74,7 +74,7 @@ Typer.prototype.doTyping = function() {
 
 var Cursor = function(element) {
   this.element = element;
-  this.cursorDisplay = element.dataset.cursorDisplay || "_";
+  this.cursorDisplay = element.dataset.cursordisplay || "_";
   this.owner = typers[element.dataset.owner] || "";
   element.innerHTML = this.cursorDisplay;
   this.on = true;


### PR DESCRIPTION
The attribute `data-cursorDisplay` in element wasn't working because the dataset object was wrong.