### PR TITLE
Add options to randomize delay between typestroke

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -79,6 +79,16 @@
         <b>Default:</b> <code class="inset">200</code></td>
     </tr>
     <tr>
+      <td><code>data-randomizeDelay</code></td>
+      <td>Allow different delays between typed characters.<br>
+        <b>Default:</b> <code class="inset">false</code></td>
+    </tr>
+    <tr>
+      <td><code>data-delayVariance</code></td>
+      <td>Variance value for random delay between typed characters. For example if you set <code class="inset">data-delay</code> to <code class="inset">100</code> and <code class="inset">data-delayVariance</code> to <code class="inset">75</code>, the delay is randomized between 100-175 ms for each typed characters<br>
+        <b>Default:</b> half of <code class="inset">data-delay</code></td>
+    </tr>
+    <tr>
       <td><code>id</code> (<code class="note">is potential dependency</code>)</td>
       <td>A unique identifier that can be used to set the owner property of
       other objects. This must be set if a <code class="inset">cursor</code>,

--- a/typer.js
+++ b/typer.js
@@ -4,6 +4,8 @@ var Typer = function(element) {
   var words = element.dataset.words || "override these,sample typing";
   this.words = words.split(delim).filter(function(v){return v;}); // non empty words
   this.delay = element.dataset.delay || 200;
+  this.delayVariance = element.dataset.delayvariance || parseInt(this.delay)/2;
+  this.randomizeDelay = element.dataset.randomizedelay || "false";
   this.loop = element.dataset.loop || "true";
   this.deleteDelay = element.dataset.deletedelay || element.dataset.deleteDelay || 800;
 
@@ -69,9 +71,13 @@ Typer.prototype.doTyping = function() {
   }
 
   var myself = this;
+  timeoutDelay = this.randomizeDelay == "true" ?
+    (Math.random() * parseInt(this.delayVariance)) + parseInt(this.delay) :
+    this.delay;
+  console.log(timeoutDelay);
   setTimeout(function() {
     if (myself.typing) { myself.doTyping(); };
-  }, p.atWordEnd ? this.deleteDelay : this.delay);
+  }, p.atWordEnd ? this.deleteDelay : timeoutDelay);
 };
 
 var Cursor = function(element) {


### PR DESCRIPTION
# Description
Addressing 'todo': [Add human-like option that varies character delays slightly](https://github.com/straversi/Typer.js#todo)

I added options: 
- `data-randomizeDelay` (default value is `false`) 
- `data-delayVariance` (default value is half of `delay` set by user) 

Thus allow user to specify how much the delay will be randomized.

Example usage:
```
<span class="typer" id="first-typer" data-words="beets,bears,battlestar galactica" data-delay="75" data-randomizeDelay="true" data-delayVariance="100"></span>
```

Example usage:
https://jsfiddle.net/h8kxw4mo/

Modified docs preview:
https://rawgit.com/rizdaprasetya/Typer.js/patch-1/docs/index.html