### PR TITLE
Allow access to typers programmatically

### DIFF
--- a/typer.js
+++ b/typer.js
@@ -118,6 +118,7 @@ function TyperSetup() {
     t.owner = typers[e.dataset.owner];
     t.owner.cursor = t;
   }
+  window.typers = typers
 }
 
 TyperSetup();


### PR DESCRIPTION
By exporting `typers` in the `TyperSetup()` method to the `window` object, created typers can be access elsewhere in JavaScript. I think this would be a beneficial and minor edit that will allow typers to be activated based on scroll position and other developer-created optimizations.