### PR TITLE
Add options to randomize delay between typestroke

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -91,6 +91,11 @@
         <b>Default:</b> <code class="inset">200</code></td>
     </tr>
     <tr>
+      <td><code>data-delay-variance</code></td>
+      <td>Variance value for random delay between typed characters, to simulate inconsistency of human typing delay. E.g., if you set <code class="inset">data-delay="100"</code> and <code class="inset">data-delay-variance="75"</code> the delay is randomized between (100-75) ms to (100+75) ms for each typed characters<br>
+        <b>Default:</b> <code class="inset">0</code> (no variance, static delay)</td>
+    </tr>
+    <tr>
       <td><code>data-loop</code></td>
       <td>The number of repetitons through the word set, or a boolean representing whether to loop infinitely or once.<br>
         <b>Default:</b> <code class="inset">true</code> (loop infinitely)</td>

--- a/typer.js
+++ b/typer.js
@@ -3,7 +3,8 @@ var Typer = function(element) {
   var delim = element.dataset.delim || ",";
   var words = element.dataset.words || "override these,sample typing";
   this.words = words.split(delim).filter((v) => v); // non empty words
-  this.delay = element.dataset.delay || 200;
+  this.delayVariance = parseInt(element.dataset.delayVariance) || 0;
+  this.delay = parseInt(element.dataset.delay) || 200;
   this.loop = element.dataset.loop || "true";
   if (this.loop === "false" ) { this.loop = 1 }
   this.deleteDelay = element.dataset.deletedelay || element.dataset.deleteDelay || 800;
@@ -35,6 +36,7 @@ Typer.prototype.doTyping = function() {
   var c = p.char;
   var currentDisplay = [...this.words[w]].slice(0, c).join("");
   var atWordEnd;
+  var timeoutDelay = ((2 * Math.random() - 1) * this.delayVariance) + this.delay;
   if (this.cursor) {
     this.cursor.element.style.opacity = "1";
     this.cursor.on = true;
@@ -72,7 +74,7 @@ Typer.prototype.doTyping = function() {
 
   setTimeout(() => {
     if (this.typing) { this.doTyping() };
-  }, atWordEnd ? this.deleteDelay : this.delay);
+  }, atWordEnd ? this.deleteDelay : timeoutDelay);
 };
 
 var Cursor = function(element) {


### PR DESCRIPTION
# Description
Addressing `todo`: [Add human-like option that varies character delays slightly](https://github.com/straversi/Typer.js#todo)

And the great feedback here:
https://github.com/straversi/Typer.js/pull/11#issuecomment-480467293

I added options: 
- `data-delay-variance` (default value is `0`) 

### Example Usage / Demo
```
<span class="typer" id="first-typer" data-words="beetsWithCheese,bearsWithShields,battlestar galactica" data-delay="150" data-delay-variance="50"></span>  
```
https://jsfiddle.net/Lvc1pqno/

### Modified docs preview:
https://raw.githack.com/rizdaprasetya/Typer.js/patch-2/docs/index.html